### PR TITLE
Make Serviceworkers an npm package

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,13 @@
+pwabuilder-lib
+
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,17 @@
+'use strict';
+var path = require('path');
+
+function getAssetsFolders(ids) {
+  var results = [];
+  var serviceWorkerIDs = ids.split(',');
+
+  for (var i = 0; i < serviceWorkerIDs.length; i++) {
+    results.push(path.resolve(__dirname, 'serviceWorker' + serviceWorkerIDs[i]));
+  }
+
+  return results;
+}
+
+module.exports = {
+  getAssetsFolders: getAssetsFolders
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "pwabuilder-serviceworkers",
+  "version": "1.0.0",
+  "description": "PWA Builder Core Library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pwa-builder/serviceworkers.git"
+  },
+  "author": {
+    "name": "TBD",
+    "email": "TBD",
+    "url": "TBD"
+  },
+  "license": "MIT",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/pwa-builder/serviceworkers/blob/master/LICENSE.txt"
+    }
+  ],
+  "keywords": [
+    "convert manifest",
+    "manifest",
+    "W3C",
+    "Manifold",
+    "ManifoldJS",
+    "PWABuilder"
+  ],
+  "bugs": {
+    "url": "https://github.com/pwa-builder/serviceworkers//issues"
+  },
+  "homepage": "https://github.com/pwa-builder/serviceworkers/"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-serviceworkers",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "PWA Builder Core Library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added:
- package.json (with no dependencies)
- LICENSE.txt (MIT)
- index.js (getAssetsFolders resolves script assets folder)