### PR TITLE
Add filters to avoid fetch strategies issues

### DIFF
--- a/serviceWorker1/pwabuilder-sw.js
+++ b/serviceWorker1/pwabuilder-sw.js
@@ -19,17 +19,16 @@ self.addEventListener("install", function (event) {
 self.addEventListener("fetch", function (event) {
   if (event.request.method !== "GET") return;
 
-  
-  // The following validates that the request is for a navigation to a new document
-  if (
-    event.request.destination !== "document" ||
-    event.request.mode !== "navigate"
-  ) {
-    return;
-  }
-
   event.respondWith(
     fetch(event.request).catch(function (error) {
+      // The following validates that the request was for a navigation to a new document
+      if (
+        event.request.destination !== "document" ||
+        event.request.mode !== "navigate"
+      ) {
+        return;
+      }
+
       console.error("[PWA Builder] Network request Failed. Serving offline page " + error);
       return caches.open(CACHE).then(function (cache) {
         return cache.match("offline.html");

--- a/serviceWorker1/pwabuilder-sw.js
+++ b/serviceWorker1/pwabuilder-sw.js
@@ -18,6 +18,8 @@ self.addEventListener("install", function (event) {
 // If any fetch fails, it will show the offline page.
 // Maybe this should be limited to HTML documents?
 self.addEventListener("fetch", function (event) {
+  if (event.request.method !== 'GET') return;
+  
   event.respondWith(
     fetch(event.request).catch(function (error) {
       console.error("[PWA Builder] Network request Failed. Serving offline page " + error);

--- a/serviceWorker1/pwabuilder-sw.js
+++ b/serviceWorker1/pwabuilder-sw.js
@@ -16,10 +16,18 @@ self.addEventListener("install", function (event) {
 });
 
 // If any fetch fails, it will show the offline page.
-// Maybe this should be limited to HTML documents?
 self.addEventListener("fetch", function (event) {
-  if (event.request.method !== 'GET') return;
+  if (event.request.method !== "GET") return;
+
   
+  // The following validates that the request is for a navigation to a new document
+  if (
+    event.request.destination !== "document" ||
+    event.request.mode !== "navigate"
+  ) {
+    return;
+  }
+
   event.respondWith(
     fetch(event.request).catch(function (error) {
       console.error("[PWA Builder] Network request Failed. Serving offline page " + error);

--- a/serviceWorker2/pwabuilder-sw.js
+++ b/serviceWorker2/pwabuilder-sw.js
@@ -17,6 +17,8 @@ self.addEventListener("install", function (event) {
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
 self.addEventListener("fetch", function (event) {
+  if (event.request.method !== 'GET') return;
+
   event.respondWith(
     fetch(event.request)
       .then(function (response) {

--- a/serviceWorker2/pwabuilder-sw.js
+++ b/serviceWorker2/pwabuilder-sw.js
@@ -17,7 +17,7 @@ self.addEventListener("install", function (event) {
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
 self.addEventListener("fetch", function (event) {
-  if (event.request.method !== 'GET') return;
+  if (event.request.method !== "GET") return;
 
   event.respondWith(
     fetch(event.request)
@@ -29,7 +29,7 @@ self.addEventListener("fetch", function (event) {
 
         return response;
       })
-      .catch(function (error) {
+      .catch(function (error) {        
         console.log("[PWA Builder] Network request Failed. Serving content from cache: " + error);
         return fromCache(event.request);
       })
@@ -42,9 +42,11 @@ function fromCache(request) {
   // If not in the cache, then return error page
   return caches.open(CACHE).then(function (cache) {
     return cache.match(request).then(function (matching) {
-      return !matching || matching.status == 404
-        ? Promise.reject("no-match")
-        : matching;
+      if (!matching || matching.status === 404) {
+        return Promise.reject("no-match");
+      }
+
+      return matching;
     });
   });
 }

--- a/serviceWorker3/pwabuilder-sw.js
+++ b/serviceWorker3/pwabuilder-sw.js
@@ -17,7 +17,7 @@ self.addEventListener("install", function (event) {
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
 self.addEventListener("fetch", function (event) {
-  if (event.request.method !== 'GET') return;
+  if (event.request.method !== "GET") return;
 
   event.respondWith(
     fetch(event.request)
@@ -42,9 +42,16 @@ function fromCache(request) {
   // If not in the cache, then return the offline page
   return caches.open(CACHE).then(function (cache) {
     return cache.match(request).then(function (matching) {
-      return !matching || matching.status == 404
-        ? cache.match(offlinePage)
-        : matching;
+      if (!matching || matching.status === 404) {
+        // The following validates that the request was for a navigation to a new document
+        if (request.destination !== "document" || request.mode !== "navigate") {
+          return Promise.reject("no-match");
+        }
+
+        return cache.match(offlinePage);
+      }
+
+      return matching;
     });
   });
 }

--- a/serviceWorker3/pwabuilder-sw.js
+++ b/serviceWorker3/pwabuilder-sw.js
@@ -17,6 +17,8 @@ self.addEventListener("install", function (event) {
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
 self.addEventListener("fetch", function (event) {
+  if (event.request.method !== 'GET') return;
+
   event.respondWith(
     fetch(event.request)
       .then(function (response) {

--- a/serviceWorker4/pwabuilder-sw.js
+++ b/serviceWorker4/pwabuilder-sw.js
@@ -26,7 +26,9 @@ self.addEventListener("activate", function (event) {
 });
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
-self.addEventListener("fetch", function (event) {
+self.addEventListener("fetch", function (event) { 
+  if (event.request.method !== 'GET') return;
+
   event.respondWith(
     fromCache(event.request).then(
       function (response) {

--- a/serviceWorker4/pwabuilder-sw.js
+++ b/serviceWorker4/pwabuilder-sw.js
@@ -27,7 +27,7 @@ self.addEventListener("activate", function (event) {
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
 self.addEventListener("fetch", function (event) { 
-  if (event.request.method !== 'GET') return;
+  if (event.request.method !== "GET") return;
 
   event.respondWith(
     fromCache(event.request).then(
@@ -55,7 +55,6 @@ self.addEventListener("fetch", function (event) {
           })
           .catch(function (error) {
             console.log("[PWA Builder] Network request failed and no cache." + error);
-            return Promise.reject("no-match");
           });
       }
     )
@@ -65,12 +64,14 @@ self.addEventListener("fetch", function (event) {
 function fromCache(request) {
   // Check to see if you have it in the cache
   // Return response
-  // If not in the cache, then return error page
+  // If not in the cache, then return
   return caches.open(CACHE).then(function (cache) {
     return cache.match(request).then(function (matching) {
-      return !matching || matching.status == 404
-        ? Promise.reject("no-match")
-        : matching;
+      if (!matching || matching.status === 404) {
+        return Promise.reject("no-match");
+      }
+
+      return matching;
     });
   });
 }

--- a/serviceWorker5/pwabuilder-sw.js
+++ b/serviceWorker5/pwabuilder-sw.js
@@ -57,6 +57,8 @@ self.addEventListener("activate", function (event) {
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
 self.addEventListener("fetch", function (event) {
+  if (event.request.method !== 'GET') return;
+
   if (comparePaths(event.request.url, networkFirstPaths)) {
     networkFirstFetch(event);
   } else {


### PR DESCRIPTION
This PR added the logic to prevent adding caching strategies on requests that are not using the GET method (i.e. POST, PUT, DELETE, etc.). You usually don't want to do anything with requests that doesn't retrieve information.

Additionally, this PR included the logic to prevent returning the offline page on requests that are not navigation to new documents (i.e. API calls, image or css/js files requests, etc.)