### PR TITLE
Offline page strategy

### DIFF
--- a/serviceWorker1/pwabuilder-sw.js
+++ b/serviceWorker1/pwabuilder-sw.js
@@ -19,17 +19,16 @@ self.addEventListener("install", function (event) {
 self.addEventListener("fetch", function (event) {
   if (event.request.method !== "GET") return;
 
-  
-  // The following validates that the request is for a navigation to a new document
-  if (
-    event.request.destination !== "document" ||
-    event.request.mode !== "navigate"
-  ) {
-    return;
-  }
-
   event.respondWith(
     fetch(event.request).catch(function (error) {
+      // The following validates that the request was for a navigation to a new document
+      if (
+        event.request.destination !== "document" ||
+        event.request.mode !== "navigate"
+      ) {
+        return;
+      }
+
       console.error("[PWA Builder] Network request Failed. Serving offline page " + error);
       return caches.open(CACHE).then(function (cache) {
         return cache.match("offline.html");

--- a/serviceWorker1/pwabuilder-sw.js
+++ b/serviceWorker1/pwabuilder-sw.js
@@ -1,7 +1,9 @@
 // This is the "Offline page" service worker
 
 const CACHE = "pwabuilder-page";
-const offlineFallbackPage = "index.html";
+
+// TODO: replace the following with the correct offline fallback page i.e.: const offlineFallbackPage = "offline.html";
+const offlineFallbackPage = "ToDo-replace-this-name.html";
 
 // Install stage sets up the offline page in the cache and opens a new cache
 self.addEventListener("install", function (event) {
@@ -10,6 +12,11 @@ self.addEventListener("install", function (event) {
   event.waitUntil(
     caches.open(CACHE).then(function (cache) {
       console.log("[PWA Builder] Cached offline page during install");
+
+      if (offlineFallbackPage === "ToDo-replace-this-name.html") {
+        return cache.add(new Response("TODO: Update the value of the offlineFallbackPage constant in the serviceworker."));
+      }
+
       return cache.add(offlineFallbackPage);
     })
   );

--- a/serviceWorker1/pwabuilder-sw.js
+++ b/serviceWorker1/pwabuilder-sw.js
@@ -1,7 +1,7 @@
 // This is the "Offline page" service worker
 
 const CACHE = "pwabuilder-page";
-const offlinePage = "index.html";
+const offlineFallbackPage = "index.html";
 
 // Install stage sets up the offline page in the cache and opens a new cache
 self.addEventListener("install", function (event) {
@@ -10,7 +10,7 @@ self.addEventListener("install", function (event) {
   event.waitUntil(
     caches.open(CACHE).then(function (cache) {
       console.log("[PWA Builder] Cached offline page during install");
-      return cache.add(offlinePage);
+      return cache.add(offlineFallbackPage);
     })
   );
 });
@@ -31,7 +31,7 @@ self.addEventListener("fetch", function (event) {
 
       console.error("[PWA Builder] Network request Failed. Serving offline page " + error);
       return caches.open(CACHE).then(function (cache) {
-        return cache.match("offline.html");
+        return cache.match(offlineFallbackPage);
       });
     })
   );
@@ -39,9 +39,9 @@ self.addEventListener("fetch", function (event) {
 
 // This is an event that can be fired from your page to tell the SW to update the offline page
 self.addEventListener("refreshOffline", function () {
-  const offlinePageRequest = new Request(offlinePage);
+  const offlinePageRequest = new Request(offlineFallbackPage);
 
-  return fetch(offlinePage).then(function (response) {
+  return fetch(offlineFallbackPage).then(function (response) {
     return caches.open(CACHE).then(function (cache) {
       console.log("[PWA Builder] Offline page updated from refreshOffline event: " + response.url);
       return cache.put(offlinePageRequest, response);

--- a/serviceWorker1/pwabuilder-sw.js
+++ b/serviceWorker1/pwabuilder-sw.js
@@ -18,6 +18,8 @@ self.addEventListener("install", function (event) {
 // If any fetch fails, it will show the offline page.
 // Maybe this should be limited to HTML documents?
 self.addEventListener("fetch", function (event) {
+  if (event.request.method !== 'GET') return;
+  
   event.respondWith(
     fetch(event.request).catch(function (error) {
       console.error("[PWA Builder] Network request Failed. Serving offline page " + error);

--- a/serviceWorker1/pwabuilder-sw.js
+++ b/serviceWorker1/pwabuilder-sw.js
@@ -16,10 +16,18 @@ self.addEventListener("install", function (event) {
 });
 
 // If any fetch fails, it will show the offline page.
-// Maybe this should be limited to HTML documents?
 self.addEventListener("fetch", function (event) {
-  if (event.request.method !== 'GET') return;
+  if (event.request.method !== "GET") return;
+
   
+  // The following validates that the request is for a navigation to a new document
+  if (
+    event.request.destination !== "document" ||
+    event.request.mode !== "navigate"
+  ) {
+    return;
+  }
+
   event.respondWith(
     fetch(event.request).catch(function (error) {
       console.error("[PWA Builder] Network request Failed. Serving offline page " + error);

--- a/serviceWorker2/pwabuilder-sw.js
+++ b/serviceWorker2/pwabuilder-sw.js
@@ -1,7 +1,7 @@
 // This is the "Offline copy of pages" service worker
 
 const CACHE = "pwabuilder-offline";
-const offlinePage = "index.html";
+const offlineFallbackPage = "index.html";
 
 // Install stage sets up the index page (home page) in the cache and opens a new cache
 self.addEventListener("install", function (event) {
@@ -10,7 +10,7 @@ self.addEventListener("install", function (event) {
   event.waitUntil(
     caches.open(CACHE).then(function (cache) {
       console.log("[PWA Builder] Cached offline page during install");
-      return cache.add(offlinePage);
+      return cache.add(offlineFallbackPage);
     })
   );
 });

--- a/serviceWorker2/pwabuilder-sw.js
+++ b/serviceWorker2/pwabuilder-sw.js
@@ -17,6 +17,8 @@ self.addEventListener("install", function (event) {
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
 self.addEventListener("fetch", function (event) {
+  if (event.request.method !== 'GET') return;
+
   event.respondWith(
     fetch(event.request)
       .then(function (response) {

--- a/serviceWorker2/pwabuilder-sw.js
+++ b/serviceWorker2/pwabuilder-sw.js
@@ -17,7 +17,7 @@ self.addEventListener("install", function (event) {
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
 self.addEventListener("fetch", function (event) {
-  if (event.request.method !== 'GET') return;
+  if (event.request.method !== "GET") return;
 
   event.respondWith(
     fetch(event.request)
@@ -29,7 +29,7 @@ self.addEventListener("fetch", function (event) {
 
         return response;
       })
-      .catch(function (error) {
+      .catch(function (error) {        
         console.log("[PWA Builder] Network request Failed. Serving content from cache: " + error);
         return fromCache(event.request);
       })
@@ -42,9 +42,11 @@ function fromCache(request) {
   // If not in the cache, then return error page
   return caches.open(CACHE).then(function (cache) {
     return cache.match(request).then(function (matching) {
-      return !matching || matching.status == 404
-        ? Promise.reject("no-match")
-        : matching;
+      if (!matching || matching.status === 404) {
+        return Promise.reject("no-match");
+      }
+
+      return matching;
     });
   });
 }

--- a/serviceWorker2/pwabuilder-sw.js
+++ b/serviceWorker2/pwabuilder-sw.js
@@ -1,7 +1,9 @@
 // This is the "Offline copy of pages" service worker
 
 const CACHE = "pwabuilder-offline";
-const offlineFallbackPage = "index.html";
+
+// TODO: replace the following with the correct offline fallback page i.e.: const offlineFallbackPage = "index.html";
+const offlineFallbackPage = "ToDo-replace-this-name.html";
 
 // Install stage sets up the index page (home page) in the cache and opens a new cache
 self.addEventListener("install", function (event) {
@@ -10,6 +12,11 @@ self.addEventListener("install", function (event) {
   event.waitUntil(
     caches.open(CACHE).then(function (cache) {
       console.log("[PWA Builder] Cached offline page during install");
+
+      if (offlineFallbackPage === "ToDo-replace-this-name.html") {
+        return cache.add(new Response("TODO: Update the value of the offlineFallbackPage constant in the serviceworker."));
+      }
+      
       return cache.add(offlineFallbackPage);
     })
   );

--- a/serviceWorker3/pwabuilder-sw.js
+++ b/serviceWorker3/pwabuilder-sw.js
@@ -1,7 +1,9 @@
 // This is the service worker with the combined offline experience (Offline page + Offline copy of pages)
 
 const CACHE = "pwabuilder-offline-page";
-const offlineFallbackPage = "offline.html";
+
+// TODO: replace the following with the correct offline fallback page i.e.: const offlineFallbackPage = "offline.html";
+const offlineFallbackPage = "ToDo-replace-this-name.html";
 
 // Install stage sets up the offline page in the cache and opens a new cache
 self.addEventListener("install", function (event) {
@@ -10,6 +12,11 @@ self.addEventListener("install", function (event) {
   event.waitUntil(
     caches.open(CACHE).then(function (cache) {
       console.log("[PWA Builder] Cached offline page during install");
+      
+      if (offlineFallbackPage === "ToDo-replace-this-name.html") {
+        return cache.add(new Response("TODO: Update the value of the offlineFallbackPage constant in the serviceworker."));
+      }
+      
       return cache.add(offlineFallbackPage);
     })
   );

--- a/serviceWorker3/pwabuilder-sw.js
+++ b/serviceWorker3/pwabuilder-sw.js
@@ -17,7 +17,7 @@ self.addEventListener("install", function (event) {
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
 self.addEventListener("fetch", function (event) {
-  if (event.request.method !== 'GET') return;
+  if (event.request.method !== "GET") return;
 
   event.respondWith(
     fetch(event.request)
@@ -42,9 +42,16 @@ function fromCache(request) {
   // If not in the cache, then return the offline page
   return caches.open(CACHE).then(function (cache) {
     return cache.match(request).then(function (matching) {
-      return !matching || matching.status == 404
-        ? cache.match(offlinePage)
-        : matching;
+      if (!matching || matching.status === 404) {
+        // The following validates that the request was for a navigation to a new document
+        if (request.destination !== "document" || request.mode !== "navigate") {
+          return Promise.reject("no-match");
+        }
+
+        return cache.match(offlinePage);
+      }
+
+      return matching;
     });
   });
 }

--- a/serviceWorker3/pwabuilder-sw.js
+++ b/serviceWorker3/pwabuilder-sw.js
@@ -17,6 +17,8 @@ self.addEventListener("install", function (event) {
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
 self.addEventListener("fetch", function (event) {
+  if (event.request.method !== 'GET') return;
+
   event.respondWith(
     fetch(event.request)
       .then(function (response) {

--- a/serviceWorker3/pwabuilder-sw.js
+++ b/serviceWorker3/pwabuilder-sw.js
@@ -1,7 +1,7 @@
 // This is the service worker with the combined offline experience (Offline page + Offline copy of pages)
 
 const CACHE = "pwabuilder-offline-page";
-const offlinePage = "offline.html";
+const offlineFallbackPage = "offline.html";
 
 // Install stage sets up the offline page in the cache and opens a new cache
 self.addEventListener("install", function (event) {
@@ -10,7 +10,7 @@ self.addEventListener("install", function (event) {
   event.waitUntil(
     caches.open(CACHE).then(function (cache) {
       console.log("[PWA Builder] Cached offline page during install");
-      return cache.add(offlinePage);
+      return cache.add(offlineFallbackPage);
     })
   );
 });
@@ -48,7 +48,7 @@ function fromCache(request) {
           return Promise.reject("no-match");
         }
 
-        return cache.match(offlinePage);
+        return cache.match(offlineFallbackPage);
       }
 
       return matching;

--- a/serviceWorker4/pwabuilder-sw.js
+++ b/serviceWorker4/pwabuilder-sw.js
@@ -26,7 +26,9 @@ self.addEventListener("activate", function (event) {
 });
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
-self.addEventListener("fetch", function (event) {
+self.addEventListener("fetch", function (event) { 
+  if (event.request.method !== 'GET') return;
+
   event.respondWith(
     fromCache(event.request).then(
       function (response) {

--- a/serviceWorker4/pwabuilder-sw.js
+++ b/serviceWorker4/pwabuilder-sw.js
@@ -27,7 +27,7 @@ self.addEventListener("activate", function (event) {
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
 self.addEventListener("fetch", function (event) { 
-  if (event.request.method !== 'GET') return;
+  if (event.request.method !== "GET") return;
 
   event.respondWith(
     fromCache(event.request).then(
@@ -55,7 +55,6 @@ self.addEventListener("fetch", function (event) {
           })
           .catch(function (error) {
             console.log("[PWA Builder] Network request failed and no cache." + error);
-            return Promise.reject("no-match");
           });
       }
     )
@@ -65,12 +64,14 @@ self.addEventListener("fetch", function (event) {
 function fromCache(request) {
   // Check to see if you have it in the cache
   // Return response
-  // If not in the cache, then return error page
+  // If not in the cache, then return
   return caches.open(CACHE).then(function (cache) {
     return cache.match(request).then(function (matching) {
-      return !matching || matching.status == 404
-        ? Promise.reject("no-match")
-        : matching;
+      if (!matching || matching.status === 404) {
+        return Promise.reject("no-match");
+      }
+
+      return matching;
     });
   });
 }

--- a/serviceWorker5/pwabuilder-sw.js
+++ b/serviceWorker5/pwabuilder-sw.js
@@ -4,7 +4,9 @@ const CACHE = "pwabuilder-adv-cache";
 const precacheFiles = [
   /* Add an array of files to precache for your app */
 ];
-const offlineFallbackPage = "offline.html";
+
+// TODO: replace the following with the correct offline fallback page i.e.: const offlineFallbackPage = "offline.html";
+const offlineFallbackPage = "ToDo-replace-this-name.html";
 
 const networkFirstPaths = [
   /* Add an array of regex of paths that should go network first */
@@ -42,8 +44,13 @@ self.addEventListener("install", function (event) {
   event.waitUntil(
     caches.open(CACHE).then(function (cache) {
       console.log("[PWA Builder] Caching pages during install");
-      return cache.add(offlineFallbackPage).then(function () {
-        return cache.addAll(precacheFiles);
+
+      return cache.addAll(precacheFiles).then(function () {
+        if (offlineFallbackPage === "ToDo-replace-this-name.html") {
+          return cache.add(new Response("TODO: Update the value of the offlineFallbackPage constant in the serviceworker."));
+        }
+
+        return cache.add(offlineFallbackPage);
       });
     })
   );

--- a/serviceWorker5/pwabuilder-sw.js
+++ b/serviceWorker5/pwabuilder-sw.js
@@ -57,6 +57,8 @@ self.addEventListener("activate", function (event) {
 
 // If any fetch fails, it will look for the request in the cache and serve it from there first
 self.addEventListener("fetch", function (event) {
+  if (event.request.method !== 'GET') return;
+
   if (comparePaths(event.request.url, networkFirstPaths)) {
     networkFirstFetch(event);
   } else {


### PR DESCRIPTION
This PR updates the offline fallback page name approach so you need to update the page to use it on production, but it will not throw an exception for not finding the file.

If you don't update the file name you will end up getting a message saying `TODO: Update the value of the offlineFallbackPage constant in the serviceworker` instead of an offline page