### PR TITLE
fix: add missing workbox script

### DIFF
--- a/serviceWorker3/pwabuilder-sw.js
+++ b/serviceWorker3/pwabuilder-sw.js
@@ -1,5 +1,7 @@
 // This is the service worker with the combined offline experience (Offline page + Offline copy of pages)
 
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.0.0/workbox-sw.js');
+
 const CACHE = "pwabuilder-offline-page";
 
 // TODO: replace the following with the correct offline fallback page i.e.: const offlineFallbackPage = "offline.html";


### PR DESCRIPTION
Hello, the workbox script seems to be missing from the serviceWorker3 (Offline copy with Backup offline page)  file.

I discovered this issue yesterday while using the pwabuilder-sw.js script and getting a lot of workbox is undefined errors, until I manually added the workbox script.

I have added the workbox script now on this pull request, but I don't know if it was intentionally left out.